### PR TITLE
Deferred Refinements/interface change

### DIFF
--- a/src/graphql/DeferredLoaderBuilder.hx
+++ b/src/graphql/DeferredLoaderBuilder.hx
@@ -19,25 +19,9 @@ class DeferredLoaderBuilder {
                 if(!f.access.contains(AStatic)) {
                     throw new Error("Load function must be static", f.pos);
                 }
-                switch (f.kind) {
-                    case(FFun({ret: ret})):
-                        switch(ret) {
-                            case TPath({name: 'Map', params: p}):
-                                switch(p[0]) {
-                                    case(TPType(t)):
-                                        keyType = t;
-                                    default: throw new Error("Bad key type", f.pos);
-                                }
-                                switch(p[1]) {
-                                    case(TPType(t)):
-                                        returnType = t;
-                                    default: throw new Error("Invalid loader return type", f.pos);
-                                }
-                            default:
-                                throw new Error("Load function must return a Map", f.pos);
-                        }
-                    default: throw new Error("load property must be a function", f.pos);
-                }
+                var types = getLoaderValueTypes(f);
+                keyType = types.key;
+                returnType = types.ret;
             }
         }
         if(!hasLoad) {
@@ -65,5 +49,33 @@ class DeferredLoaderBuilder {
 			fields.push(field);
 		}
 		return fields;
+    }
+
+    public static function getLoaderValueTypes(f:Field) {
+        var keyType : ComplexType;
+        var returnType : ComplexType;
+        switch (f.kind) {
+            case(FFun({ret: ret})):
+                switch(ret) {
+                    case TPath({name: 'Map', params: p}):
+                        switch(p[0]) {
+                            case(TPType(t)):
+                                keyType = t;
+                            default: throw new Error("Bad key type", f.pos);
+                        }
+                        switch(p[1]) {
+                            case(TPType(t)):
+                                returnType = t;
+                            default: throw new Error("Invalid loader return type", f.pos);
+                        }
+                    default:
+                        throw new Error("Load function must return a Map", f.pos);
+                }
+            default: throw new Error("load property must be a function", f.pos);
+        }
+        return {
+            key: keyType,
+            ret: returnType
+        };
     }
 }

--- a/src/graphql/DeferredLoaderBuilder.hx
+++ b/src/graphql/DeferredLoaderBuilder.hx
@@ -29,19 +29,26 @@ class DeferredLoaderBuilder {
         }
 		var tmp_class = macro class {
             static var keys:Array<$keyType> = [];
-            public static var values : Null<Map<$keyType,$returnType>> = null;
-            static var loaded = false;
+            public static var values : Map<$keyType,$returnType> = [];
+            static var runCount = 0;
 
             public static function add(key:$keyType) {
                 if(!keys.contains(key)) {
                     keys.push(key);
                 }
             }
-            public static function loadOnce() : Void {
-                if(!loaded) {
-                    values = load();
-                    loaded = true;
+
+            public static function getValue(key:$keyType) : $returnType {
+                var loadedKeys = [for (k in values.keys()) k];
+                if(!loadedKeys.contains(key)) {
+                    var newValues = load();
+                    for(k => v in newValues) {
+                        values[k] = v;
+                    }
+                    keys = [];
+                    runCount++;
                 }
+                return values[key];
             }
         }
         

--- a/src/graphql/DeferredLoaderBuilder.hx
+++ b/src/graphql/DeferredLoaderBuilder.hx
@@ -45,26 +45,19 @@ class DeferredLoaderBuilder {
         }
 		var tmp_class = macro class {
             static var keys:Array<$keyType> = [];
-            static var values : Null<Map<$keyType,$returnType>> = null;
+            public static var values : Null<Map<$keyType,$returnType>> = null;
             static var loaded = false;
 
-            static function add(key:$keyType) {
+            public static function add(key:$keyType) {
                 if(!keys.contains(key)) {
                     keys.push(key);
                 }
             }
-            static function loadOnce() : Void {
+            public static function loadOnce() : Void {
                 if(!loaded) {
                     values = load();
                     loaded = true;
                 }
-            }
-            public static function get(id:$keyType) : graphql.externs.Deferred<$returnType> {
-                add(id);
-                return new graphql.externs.Deferred(() -> {
-                    loadOnce();
-                    return values[id];
-                });
             }
         }
         

--- a/src/graphql/DeferredLoaderBuilder.hx
+++ b/src/graphql/DeferredLoaderBuilder.hx
@@ -17,7 +17,7 @@ class DeferredLoaderBuilder {
             if(f.name == 'load') {
                 hasLoad = true;
                 if(!f.access.contains(AStatic)) {
-                    throw new Error("Load function must be static", Context.currentPos());
+                    throw new Error("Load function must be static", f.pos);
                 }
                 switch (f.kind) {
                     case(FFun({ret: ret})):
@@ -26,17 +26,17 @@ class DeferredLoaderBuilder {
                                 switch(p[0]) {
                                     case(TPType(t)):
                                         keyType = t;
-                                    default: throw new Error("Bad key type", Context.currentPos());
+                                    default: throw new Error("Bad key type", f.pos);
                                 }
                                 switch(p[1]) {
                                     case(TPType(t)):
                                         returnType = t;
-                                    default: throw new Error("Invalid loader return type", Context.currentPos());
+                                    default: throw new Error("Invalid loader return type", f.pos);
                                 }
                             default:
-                                throw new Error("Load function must return a Map", Context.currentPos());
+                                throw new Error("Load function must return a Map", f.pos);
                         }
-                    default: throw new Error("load property must be a function", Context.currentPos());
+                    default: throw new Error("load property must be a function", f.pos);
                 }
             }
         }

--- a/src/graphql/FieldMetadata.hx
+++ b/src/graphql/FieldMetadata.hx
@@ -16,4 +16,5 @@ enum abstract FieldMetadata(String) from String to String {
 	var ClassValidationContext = "validationContext";
 	var ContextVar = "context";
 	var DocMeta = "doc";
+	var Deferred = "deferred";
 }

--- a/src/graphql/FieldTypeBuilder.hx
+++ b/src/graphql/FieldTypeBuilder.hx
@@ -203,6 +203,15 @@ class FieldTypeBuilder {
 	public function getDeferredLoaderClass() {
 		return getMeta(Deferred).params[0];
 	}
+
+	public function getFunctionBody() {
+		switch(field.kind) {
+			case FFun({expr: expr}):
+				return expr;
+			default:
+				return throw new Error("Not a function", field.pos);
+		}
+	}
     
     function hasMeta(name : FieldMetadata, allowMultiple = false) {
 		var found = false;

--- a/src/graphql/FieldTypeBuilder.hx
+++ b/src/graphql/FieldTypeBuilder.hx
@@ -16,6 +16,7 @@ class FieldTypeBuilder {
     public var args : Expr = macro [];
     public var arg_names: Array<String> = [];
     public var is_function = false;
+	public var is_deferred = false;
 
 	public var query_type : GraphQLObjectType;
 
@@ -55,6 +56,7 @@ class FieldTypeBuilder {
 			var base_type = nullableType(params);
 			return macro $base_type;
 		} else if (name == 'Deferred') {
+			is_deferred = true;
             var deferredOf = arrayType(params);
 			return macro $deferredOf;
 		} else {

--- a/src/graphql/FieldTypeBuilder.hx
+++ b/src/graphql/FieldTypeBuilder.hx
@@ -195,6 +195,14 @@ class FieldTypeBuilder {
 	public function isStatic() : Bool {
 		return field.access.contains(AStatic);
 	}
+
+	public function isMagicDeferred() : Bool {
+		return hasMeta(Deferred);
+	}
+
+	public function getDeferredLoaderClass() {
+		return getMeta(Deferred).params[0];
+	}
     
     function hasMeta(name : FieldMetadata, allowMultiple = false) {
 		var found = false;

--- a/src/graphql/FieldTypeBuilder.hx
+++ b/src/graphql/FieldTypeBuilder.hx
@@ -212,6 +212,25 @@ class FieldTypeBuilder {
 				return throw new Error("Not a function", field.pos);
 		}
 	}
+
+	public function getFunctionReturnType() {
+		switch(field.kind) {
+			case FFun({ret: ret}):
+				return ret;
+			default:
+				return throw new Error("Not a function", field.pos);
+		}
+	}
+    
+
+	public function getFunctionArgType(i:Int = 0) {
+		switch(field.kind) {
+			case FFun({args: args}):
+				return args[0].type;
+			default:
+				return throw new Error("Not a function", field.pos);
+		}
+	}
     
     function hasMeta(name : FieldMetadata, allowMultiple = false) {
 		var found = false;

--- a/src/graphql/FieldTypeBuilder.hx
+++ b/src/graphql/FieldTypeBuilder.hx
@@ -204,6 +204,10 @@ class FieldTypeBuilder {
 		return getMeta(Deferred).params[0];
 	}
 
+	public function getDeferredLoaderExpresssion() {
+		return getMeta(Deferred).params[1];
+	}
+
 	public function getFunctionBody() {
 		switch(field.kind) {
 			case FFun({expr: expr}):

--- a/src/graphql/TypeBuilder.hx
+++ b/src/graphql/TypeBuilder.hx
@@ -171,6 +171,9 @@ class TypeBuilder {
 				Util.debug('$name is deferred');
 				var loader = field.getDeferredLoaderClass();
 				var arg = field.arg_names[0];
+				if(field.getFunctionBody() != null) {
+					throw new Error("Magic deferred loader should not have a function body", f.pos);
+				}
 				if(field.arg_names.length != 1) {
 					throw new Error("Magic deferred loader must have exactly one argument", f.pos);
 				}

--- a/src/graphql/TypeBuilder.hx
+++ b/src/graphql/TypeBuilder.hx
@@ -190,8 +190,7 @@ class TypeBuilder {
 					var id = $idExpr;
 					$loader.add(id);
 					return new graphql.externs.Deferred(() -> {
-						$loader.loadOnce();
-						var result : $returnType = $loader.values[id];
+						var result : $returnType = $loader.getValue(id);
 						$b{postValidations};
 						return result;
 					});

--- a/src/graphql/TypeBuilder.hx
+++ b/src/graphql/TypeBuilder.hx
@@ -170,17 +170,24 @@ class TypeBuilder {
 			if(field.isMagicDeferred()) {
 				Util.debug('$name is deferred');
 				var loader = field.getDeferredLoaderClass();
-				var arg = field.arg_names[0];
+				var loaderExpression = field.getDeferredLoaderExpresssion();
 				if(field.getFunctionBody() != null) {
 					throw new Error("Magic deferred loader should not have a function body", f.pos);
 				}
-				if(field.arg_names.length != 1) {
-					throw new Error("Magic deferred loader must have exactly one argument", f.pos);
+				var idExpr = macro {};
+				if(loaderExpression == null) {
+					if(field.arg_names.length != 1) {
+						throw new Error("Deferred loader without expression must have exactly one argument", f.pos);
+					}
+					var arg = field.arg_names[0];
+					var argType = field.getFunctionArgType(0);
+					idExpr = macro ( $i{ arg } : $argType );
+				} else {
+					idExpr = loaderExpression;
 				}
 				var returnType = field.getFunctionReturnType();
-				var argType = field.getFunctionArgType(0);
 				getResult = macro {
-					var id : $argType = $i{ arg };
+					var id = $idExpr;
 					$loader.add(id);
 					return new graphql.externs.Deferred(() -> {
 						$loader.loadOnce();

--- a/src/graphql/TypeBuilder.hx
+++ b/src/graphql/TypeBuilder.hx
@@ -177,12 +177,14 @@ class TypeBuilder {
 				if(field.arg_names.length != 1) {
 					throw new Error("Magic deferred loader must have exactly one argument", f.pos);
 				}
+				var returnType = field.getFunctionReturnType();
+				var argType = field.getFunctionArgType(0);
 				getResult = macro {
-					var id = $i{ arg };
+					var id : $argType = $i{ arg };
 					$loader.add(id);
 					return new graphql.externs.Deferred(() -> {
 						$loader.loadOnce();
-						var result = $loader.values[id];
+						var result : $returnType = $loader.values[id];
 						$b{postValidations};
 						return result;
 					});

--- a/src/graphql/TypeBuilder.hx
+++ b/src/graphql/TypeBuilder.hx
@@ -171,6 +171,9 @@ class TypeBuilder {
 				Util.debug('$name is deferred');
 				var loader = field.getDeferredLoaderClass();
 				var arg = field.arg_names[0];
+				if(field.arg_names.length != 1) {
+					throw new Error("Magic deferred loader must have exactly one argument", f.pos);
+				}
 				getResult = macro {
 					var id = $i{ arg };
 					$loader.add(id);

--- a/src/tests/cases/DeferredTest.hx
+++ b/src/tests/cases/DeferredTest.hx
@@ -35,6 +35,7 @@ class DeferredTest extends Test {
             getSubObject {
                 getValue(id: $id)
                 value2:getValue(id: $id3)
+                objectValue:getObjectValue
             }
         }", {
             id: 42,
@@ -49,6 +50,7 @@ class DeferredTest extends Test {
         var subObject : NativeArray = result.data['getSubObject'];
         subObject['getValue'] == "This is the value for id 42, loaded";
         subObject['value2'] == "This is the value for id 13, loaded";
+        subObject['objectValue'] == "This is the value for id 13, loaded";
         Assert.equals(42, result.data['getStaticValue']);
 
         @:privateAccess DeferredTestLoader.loaded == true;
@@ -91,8 +93,13 @@ class DeferredTestObject implements GraphQLObject {
 class DeferredTestSubObject implements GraphQLObject {
     public function new() {}
 
+    var objectProperty = 13;
+
     @:deferred(tests.cases.DeferredTestLoader)
     public function getValue(id:Int) : String;
+
+    @:deferred(tests.cases.DeferredTestLoader, obj.objectProperty)
+    public function getObjectValue() : String;
 }
 
 class DeferredTestLoader extends DeferredLoader {

--- a/src/tests/cases/ResolverTest.hx
+++ b/src/tests/cases/ResolverTest.hx
@@ -71,6 +71,26 @@ class ResolverTest extends utest.Test {
         error.isClientSafe() == true;
     }
 
+    function specProtectedNullableAddObjectValueMethod() {
+        var response = server.executeQuery("query($x:Int!, $y:Int!){
+            protectedNullableAddObjectValue(x:$x, y:$y)
+        }", {
+            x: 5,
+            y: 12
+        }.associativeArrayOfObject());
+        
+        Assert.notNull(response.data);
+        response.data['protectedNullableAddObjectValue'] == null;
+
+        Assert.notNull(response.errors);
+        var errors = response.errors.toHaxeArray();
+        errors.length == 1;
+        var error : GraphQLError = errors[0];
+        @:privateAccess error.getMessage() == 'Validation failed';
+        error.getCategory() == 'validation';
+        error.isClientSafe() == true;
+    }
+
     function specListMethod() {
         // Using just the default values
         var response = server.executeQuery("{list}");
@@ -236,6 +256,8 @@ class ResolverTest extends utest.Test {
 class ResolverTestObject implements GraphQLObject {
     public function new() {}
 
+    var falseValue = false;
+
     public function simpleMethod() : String {
         return "This is a simple response";
     }
@@ -246,6 +268,11 @@ class ResolverTestObject implements GraphQLObject {
 
     @:validate(false)
     public function protectedAdd(x:Int, y:Int) : Int {
+        return x + y;
+    }
+
+    @:validate(obj.falseValue)
+    public function protectedNullableAddObjectValue(x:Int, y:Int) : Null<Int> {
         return x + y;
     }
 


### PR DESCRIPTION
Overhauls the previous deferred resolver approach, replacing it with `@:deferred` metadata declaration. Also allows for post-validation of the yielded result, which the previous approach did not.